### PR TITLE
Added incremental predicates

### DIFF
--- a/macros/tables/snowflake/sat.sql
+++ b/macros/tables/snowflake/sat.sql
@@ -29,6 +29,7 @@
 {%- set window_cols = automate_dv.expand_column_list(columns=[src_pk, src_hashdiff, src_ldts]) -%}
 {%- set pk_cols = automate_dv.expand_column_list(columns=[src_pk]) -%}
 {%- set enable_ghost_record = var('enable_ghost_records', false) -%}
+{%- set predicates = model.config.get('predicates', none) -%}
 
 {%- if model.config.materialized == 'vault_insert_by_rank' %}
     {%- set source_cols_with_rank = source_cols + [config.get('rank_column')] -%}
@@ -65,6 +66,12 @@ latest_records AS (
                 FROM source_data
             ) AS source_records
                 ON {{ automate_dv.multikey(src_pk, prefix=['current_records','source_records'], condition='=') }}
+                WHERE 1=1
+            {%- if predicates is not none %}
+                {% for predicate in predicates %}
+                    and {{ predicate }}
+                {% endfor %}
+            {% endif %}
     ) AS a
     WHERE a.rank = 1
 ),


### PR DESCRIPTION
Added incremental predicates to Snowflake satellites to limit the scan on the destination table. When adding new records to a satellite the latest_records cte pulls data from your satellite without any filtering so it doesn't limit the amount of data it pulls and it scans all the partitions in the satellite. For a big satellite with billions of records, this process takes several minutes. If you don't scan the whole table you run the risk to insert duplicates. However, if you know you might only get duplicates within 3 months you can limit the scan on the table to the last 3 months so you don't scan years worth of data, that way you speed up the incremental process dramatically.