### PR TITLE
Normalize table and column title casing

### DIFF
--- a/macros/supporting/as_of_date_window.sql
+++ b/macros/supporting/as_of_date_window.sql
@@ -79,7 +79,7 @@ new_rows_as_of AS (
     WHERE a.AS_OF_DATE >= (SELECT LAST_SAFE_LOAD_DATETIME FROM last_safe_load_datetime)
     UNION
     {%- endif %}
-    SELECT as_of_date
+    SELECT AS_OF_DATE
     FROM as_of_grain_new_entries
 ),
 

--- a/macros/tables/postgres/sat.sql
+++ b/macros/tables/postgres/sat.sql
@@ -128,7 +128,7 @@ records_to_insert AS (
         SELECT {{ automate_dv.alias_all(source_cols, 'frin') }}
         FROM first_record_in_set AS frin
         {%- if automate_dv.is_any_incremental() %}
-        LEFT JOIN LATEST_RECORDS lr
+        LEFT JOIN latest_records lr
             ON {{ automate_dv.multikey(src_pk, prefix=['lr','frin'], condition='=') }}
             AND {{ automate_dv.prefix([src_hashdiff], 'lr', alias_target='target') }} = {{ automate_dv.prefix([src_hashdiff], 'frin') }}
             WHERE {{ automate_dv.prefix([src_hashdiff], 'lr', alias_target='target') }} IS NULL


### PR DESCRIPTION
Table and column names in `sat.sql` and `as_of_date_window.sql` were changed to lower-case and upper-case respectively for standardization across the codebase. This change ensures case-insensitive handling of these entities.

Addresses the following issues:

- #209 
- #211 

There may be other instances where case sensitive collation runs into issues, but these are the two I (and others) have noticed.

I've tested these changes on my instance of SQL Server 2017, but have not conducted any extensive testing on other DBs.

P.S. contributing guideline still references dbt-vault. Please let me know if there's anything further I should add to this PR.