### PR TITLE
Add grant execution to pit and bridge materialization

### DIFF
--- a/macros/materialisations/incremental_bridge_materialization.sql
+++ b/macros/materialisations/incremental_bridge_materialization.sql
@@ -14,6 +14,7 @@
   {% endif %}
   {%- set existing_relation = load_relation(this) -%}
   {%- set tmp_relation = make_temp_relation(target_relation) -%}
+  {%- set grant_config = config.get('grants') -%}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
@@ -45,6 +46,10 @@
   {%- call statement("main") -%}
       {{ build_sql }}
   {%- endcall -%}
+
+  -- GRANTS are managed here
+  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 

--- a/macros/materialisations/incremental_pit_materialization.sql
+++ b/macros/materialisations/incremental_pit_materialization.sql
@@ -14,6 +14,7 @@
   {% endif %}
   {%- set existing_relation = load_relation(this) -%}
   {%- set tmp_relation = make_temp_relation(target_relation) -%}
+  {%- set grant_config = config.get('grants') -%}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
@@ -45,6 +46,10 @@
   {%- call statement("main") -%}
       {{ build_sql }}
   {%- endcall -%}
+
+  -- GRANTS are managed here
+  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 


### PR DESCRIPTION
**Describe the bug**
When using the materializations `pit_incremental` or `bridge_incremental`, _Grant_ statements defined in the _dbt_project_ or in models directly are not being executed at all, not even for models with other materializations like the official materializations provided by dbt.

We are aware that the PIT and BRDIGE macros have been deprecated in the latest version of AutomateDV, however, it would be great if this can still be fixed to ensure users can still make use of those macros until alternatives are provided.

**Environment**

dbt version: 1.7.13
automate_dv version: 0.11.0
Database/Platform:  Snowflake

**To Reproduce**
Steps to reproduce the behavior:
[Option 1] Test in production
1. Add a grant statement for an existing database role e.g. in the _dbt_project_ for a directory or model that is materialized as `pit_incremental` or `bridge_incremental`
2. Merge the changes and run the PROD pipeline
3. Check the grants on the respective tables in Snowflake by running `show grants on table <database_name>.<schema_name>.<table_name>;`
4. The database role that has actually been assigned in dbt has not been granted

[Option 2] Test locally
1. Add a grant statement for a database role that does not exist e.g. in the _dbt_project_ for a directory or model that is materialized as `pit_incremental` or `bridge_incremental`
5. Execute a `dbt_run` for the respective model
6. Then dbt run will be successful _(although it should fail)_

**Expected behavior**
[Option 1]
The database role that has been assigned in dbt should be granted to the respective table(s)

[Option 2]
The dbt run should fail and a SQL compilation error should be thrown stating that "Role '<role_name>' does not exist or not authorized", given that the role name does actually not exist.

**Screenshots**
dbt_project config for Business Vault
![dbt_project_config_business_vault](https://github.com/user-attachments/assets/c29e73eb-9364-4487-afb8-fba1ccc72bc7)

**Additional context**
In version 1.2 dbt has added the execution of Grant configs to their materialization macros ([Commit](https://github.com/dbt-labs/dbt-core/pull/5369/files#diff-166e98f1f0a0a6bb94f26740cb121dd7eec6c5ebde8ba9a658bc7fe86e3fa881)). However, it seems like this hasn´t been added to the AutomateDV materialization macros for PIT and BRIDGE tables.