### PR TITLE
Add support for open-source Spark. 

### DIFF
--- a/macros/internal/helpers/logging/log_relation_sources.sql
+++ b/macros/internal/helpers/logging/log_relation_sources.sql
@@ -24,3 +24,12 @@
                                                                         source_count)) -%}
     {%- endif -%}
 {% endmacro %}
+
+{% macro spark__log_relation_sources(relation, source_count) %}
+
+    {%- if execute and automate_dv.is_something(invocation_args_dict.get('which')) and invocation_args_dict.get('which') != 'docs' -%}
+
+        {%- do dbt_utils.log_info('Loading {} from {} source(s)'.format("{}.{}".format(relation.schema, relation.identifier),
+                                                                        source_count)) -%}
+    {%- endif -%}
+{% endmacro %}

--- a/macros/internal/metadata_processing/concat_ws.sql
+++ b/macros/internal/metadata_processing/concat_ws.sql
@@ -47,3 +47,9 @@ CONCAT(
     {{ automate_dv.default__concat_ws(string_list=string_list, separator=separator) }}
 
 {%- endmacro -%}
+
+{%- macro spark__concat_ws(string_list, separator="||") -%}
+
+    {{ automate_dv.default__concat_ws(string_list=string_list, separator=separator) }}
+
+{%- endmacro -%}

--- a/macros/internal/metadata_processing/get_escape_characters.sql
+++ b/macros/internal/metadata_processing/get_escape_characters.sql
@@ -48,6 +48,10 @@
     {%- do return (('`', '`')) -%}
 {%- endmacro %}
 
+{%- macro spark__get_escape_characters() %}
+    {%- do return (('`', '`')) -%}
+{%- endmacro %}
+
 {%- macro postgres__get_escape_characters() %}
     {%- do return (('"', '"')) -%}
 {%- endmacro %}

--- a/macros/materialisations/drop_temporary.sql
+++ b/macros/materialisations/drop_temporary.sql
@@ -4,12 +4,12 @@
  */
 
 {% macro drop_temporary_special(tmp_relation) %}
-    {# In databricks and sqlserver a temporary view/table can only be dropped by #}
+    {# In spark, databricks and sqlserver a temporary view/table can only be dropped by #}
     {# the connection or session that created it so drop it now before the commit below closes this session #}
 
     {%- set drop_query_name = 'DROP_QUERY-' ~ i -%}
     {% call statement(drop_query_name, fetch_result=True) -%}
-        {% if target.type == 'databricks' %}
+        {% if target.type in ['databricks', 'spark'] %}
             DROP VIEW {{ tmp_relation }};
         {% elif target.type == 'sqlserver' %}
             DROP TABLE {{ tmp_relation }};

--- a/macros/materialisations/incremental_pit_bridge_replace.sql
+++ b/macros/materialisations/incremental_pit_bridge_replace.sql
@@ -36,6 +36,17 @@
 {%- endmacro %}
 
 
+{% macro spark__incremental_pit_replace(tmp_relation, target_relation, statement_name="main") %}
+    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
+    {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
+
+    INSERT OVERWRITE {{ target_relation }} ({{ dest_cols_csv }})
+       SELECT {{ dest_cols_csv }}
+       FROM {{ tmp_relation }};
+
+{%- endmacro %}
+
+
 
 {% macro incremental_bridge_replace(tmp_relation, target_relation, statement_name="main") %}
 
@@ -61,6 +72,17 @@
 
 
 {% macro databricks__incremental_bridge_replace(tmp_relation, target_relation, statement_name="main") %}
+    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
+    {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
+
+    INSERT OVERWRITE {{ target_relation }} ({{ dest_cols_csv }})
+       SELECT {{ dest_cols_csv }}
+       FROM {{ tmp_relation }}
+    ;
+{%- endmacro %}
+
+
+{% macro spark__incremental_bridge_replace(tmp_relation, target_relation, statement_name="main") %}
     {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
     {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
 

--- a/macros/materialisations/period_mat_helpers/get_period_of_load.sql
+++ b/macros/materialisations/period_mat_helpers/get_period_of_load.sql
@@ -69,6 +69,11 @@
 {%- endmacro -%}
 
 
+{%- macro spark__get_period_of_load(period, offset, start_timestamp) -%}
+    {% do return(automate_dv.default__get_period_of_load(period=period, offset=offset, start_timestamp=start_timestamp)) %}
+{%- endmacro -%}
+
+
 {%- macro postgres__get_period_of_load(period, offset, start_timestamp) -%}
     {# Postgres uses different DateTime arithmetic #}
     {% set period_of_load_sql -%}

--- a/macros/materialisations/vault_insert_by_period_materialization.sql
+++ b/macros/materialisations/vault_insert_by_period_materialization.sql
@@ -119,7 +119,7 @@
 
             {% if 'response' in result.keys() %} {# added in v0.19.0 #}
                 {%- if not result['response']['rows_affected'] %}
-                    {% if target.type == "databricks" and result['data'] | length > 0 %}
+                    {% if target.type in ["databricks", "spark"] and result['data'] | length > 0 %}
                         {% set rows_inserted = result['data'][0][1] | int %}
                     {% else %}
                         {% set rows_inserted = 0 %}
@@ -139,9 +139,9 @@
                                                                                               period_of_load, rows_inserted,
                                                                                               model.unique_id)) }}
 
-            {# In databricks and sqlserver a temporary view/table can only be dropped by #}
+            {# In spark, databricks and sqlserver a temporary view/table can only be dropped by #}
             {# the connection or session that created it so drop it now before the commit below closes this session #}                                                                            model.unique_id)) }}
-            {% if target.type in ['databricks', 'sqlserver'] %}
+            {% if target.type in ['databricks', 'sqlserver', 'spark'] %}
                 {{ automate_dv.drop_temporary_special(tmp_relation) }}
             {% else %}
                 {% do to_drop.append(tmp_relation) %}
@@ -166,7 +166,7 @@
 
         {% if 'response' in result.keys() %} {# added in v0.19.0 #}
             {%- if not result['response']['rows_affected'] %}
-                {% if target.type == "databricks" and result['data'] | length > 0 %}
+                {% if target.type in ["databricks", "spark"] and result['data'] | length > 0 %}
                     {% set rows_inserted = result['data'][0][1] | int %}
                 {% else %}
                     {% set rows_inserted = 0 %}

--- a/macros/materialisations/vault_insert_by_rank_materialization.sql
+++ b/macros/materialisations/vault_insert_by_rank_materialization.sql
@@ -95,7 +95,7 @@
 
             {% set result = load_result(insert_query_name) %}
             {% if 'response' in result.keys() %} {# added in v0.19.0 #}
-                {# Investigate for Databricks #}
+                {# Investigate for Databricks, Spark #}
                 {%- if result['response']['rows_affected'] == None %}
                     {% set rows_inserted = 0 %}
                 {%- else %}
@@ -114,9 +114,9 @@
                                                                                           rows_inserted,
                                                                                           model.unique_id)) }}
 
-            {# In databricks and sqlserver a temporary view/table can only be dropped by #}
+            {# In spark, databricks and sqlserver a temporary view/table can only be dropped by #}
             {# the connection or session that created it so drop it now before the commit below closes this session #}                                                                            model.unique_id)) }}
-            {% if target.type in ['databricks', 'sqlserver'] %}
+            {% if target.type in ['databricks', 'sqlserver', 'spark'] %}
                 {{ automate_dv.drop_temporary_special(tmp_relation) }}
             {% else %}
                 {% do to_drop.append(tmp_relation) %}

--- a/macros/supporting/casting/cast_date.sql
+++ b/macros/supporting/casting/cast_date.sql
@@ -58,6 +58,13 @@
 {%- endmacro -%}
 
 
+{%- macro spark__cast_date(column_str, as_string=false, alias=none) -%}
+
+    {{ automate_dv.snowflake__cast_date(column_str=column_str, as_string=as_string, alias=alias)}}
+
+{%- endmacro -%}
+
+
 {%- macro postgres__cast_date(column_str, as_string=false, alias=none) -%}
 
     {%- if as_string -%}

--- a/macros/supporting/casting/cast_datetime.sql
+++ b/macros/supporting/casting/cast_datetime.sql
@@ -60,6 +60,13 @@
 {%- endmacro -%}
 
 
+{%- macro spark__cast_datetime(column_str, as_string=false, alias=none, date_type=none) -%}
+
+    {{ automate_dv.snowflake__cast_datetime(column_str=column_str, as_string=as_string, alias=alias, date_type=date_type)}}
+
+{%- endmacro -%}
+
+
 {%- macro postgres__cast_datetime(column_str, as_string=false, alias=none, date_type=none) -%}
 
     to_char(timestamp {{ column_str }}, 'YYYY-MM-DD HH24:MI:SS.MS')::timestamp

--- a/macros/supporting/data_types/type_binary.sql
+++ b/macros/supporting/data_types/type_binary.sql
@@ -49,3 +49,13 @@
     BINARY
   {%- endif -%}
 {%- endmacro -%}
+
+{%- macro spark__type_binary(for_dbt_compare=false) -%}
+  {%- set enable_native_hashes = var('enable_native_hashes', false) -%}
+
+  {%- if not enable_native_hashes -%}
+    STRING
+  {%- else -%}
+    BINARY
+  {%- endif -%}
+{%- endmacro -%}

--- a/macros/supporting/data_types/type_string.sql
+++ b/macros/supporting/data_types/type_string.sql
@@ -32,3 +32,17 @@
         VARCHAR({{ char_length }})
     {%- endif -%}
 {%- endmacro -%}
+
+{%- macro spark__type_string(is_hash=false, char_length=255) -%}
+    {%- if is_hash -%}
+        {%- if var('hash', 'MD5') | lower == 'md5' -%}
+            VARCHAR(16)
+        {%- elif var('hash', 'MD5') | lower == 'sha' -%}
+            VARCHAR(32)
+        {%- elif var('hash', 'MD5') | lower == 'sha1' -%}
+            VARCHAR(20)
+        {%- endif -%}
+    {%- else -%}
+        VARCHAR({{ char_length }})
+    {%- endif -%}
+{%- endmacro -%}

--- a/macros/supporting/hash.sql
+++ b/macros/supporting/hash.sql
@@ -119,3 +119,10 @@
     {{ automate_dv.default__hash(columns=columns, alias=alias, is_hashdiff=is_hashdiff, columns_to_escape=columns_to_escape) }}
 
 {%- endmacro -%}
+
+
+{%- macro spark__hash(columns, alias, is_hashdiff, columns_to_escape) -%}
+
+    {{ automate_dv.default__hash(columns=columns, alias=alias, is_hashdiff=is_hashdiff, columns_to_escape=columns_to_escape) }}
+
+{%- endmacro -%}

--- a/macros/supporting/hash_components/select_hash_alg.sql
+++ b/macros/supporting/hash_components/select_hash_alg.sql
@@ -73,6 +73,18 @@
 
 {% endmacro %}
 
+{% macro spark__hash_alg_md5() -%}
+
+    {%- set is_native_hashing = var('enable_native_hashes', false) -%}
+
+    {% if is_native_hashing %}
+        {%- do return('UNHEX(MD5([HASH_STRING_PLACEHOLDER]))') %}
+    {%- else -%}
+        {%- do return(automate_dv.cast_binary('UPPER(MD5([HASH_STRING_PLACEHOLDER]))', quote=false)) -%}
+    {%- endif -%}
+
+{% endmacro %}
+
 
 {#- SHA256 -#}
 
@@ -129,6 +141,18 @@
 
 {% endmacro %}
 
+{% macro spark__hash_alg_sha256() -%}
+
+    {%- set is_native_hashing = var('enable_native_hashes', false) -%}
+
+    {% if is_native_hashing %}
+        {%- do return('UNHEX(SHA2([HASH_STRING_PLACEHOLDER], 256))') %}
+    {%- else -%}
+        {%- do return(automate_dv.cast_binary('UPPER(SHA2([HASH_STRING_PLACEHOLDER], 256))', quote=false)) -%}
+    {%- endif -%}
+
+{% endmacro %}
+
 {#- SHA1 -#}
 
 {%- macro hash_alg_sha1() -%}
@@ -170,6 +194,18 @@
 {% endmacro %}
 
 {% macro databricks__hash_alg_sha1() -%}
+
+    {%- set is_native_hashing = var('enable_native_hashes', false) -%}
+
+    {% if is_native_hashing %}
+        {%- do return('UNHEX(SHA1([HASH_STRING_PLACEHOLDER]))') %}
+    {%- else -%}
+        {%- do return(automate_dv.cast_binary('UPPER(SHA1([HASH_STRING_PLACEHOLDER]))', quote=false)) -%}
+    {%- endif -%}
+
+{% endmacro %}
+
+{% macro spark__hash_alg_sha1() -%}
 
     {%- set is_native_hashing = var('enable_native_hashes', false) -%}
 

--- a/macros/supporting/hash_components/standard_column_wrapper.sql
+++ b/macros/supporting/hash_components/standard_column_wrapper.sql
@@ -53,6 +53,23 @@
 {%- endmacro -%}
 
 
+{%- macro spark__standard_column_wrapper(hash_content_casing) -%}
+
+    {%- if hash_content_casing == 'upper' -%}
+        {%- set standardise -%}
+            NULLIF(UPPER(TRIM(CAST([EXPRESSION] AS {{ automate_dv.type_string(is_hash=true) }}))), '')
+        {%- endset -%}
+    {%- else -%}
+        {%- set standardise -%}
+            NULLIF(TRIM(CAST([EXPRESSION] AS {{ automate_dv.type_string(is_hash=true) }})), '')
+        {%- endset -%}
+    {%- endif -%}
+
+    {% do return(standardise) -%}
+
+{%- endmacro -%}
+
+
 {%- macro sqlserver__standard_column_wrapper(hash_content_casing) -%}
 
     {%- if hash_content_casing == 'upper' -%}

--- a/macros/tables/spark/bridge.sql
+++ b/macros/tables/spark/bridge.sql
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Business Thinking Ltd. 2019-2025
+ * This software includes code developed by the AutomateDV (f.k.a dbtvault) Team at Business Thinking Ltd. Trading as Datavault
+ */
+
+{%- macro spark__bridge(src_pk, src_extra_columns, as_of_dates_table, bridge_walk, stage_tables_ldts, src_ldts, source_model) -%}
+
+{{- automate_dv.default__bridge(src_pk=src_pk,
+                                src_extra_columns=src_extra_columns,
+                                src_ldts=src_ldts,
+                                as_of_dates_table=as_of_dates_table,
+                                bridge_walk=bridge_walk,
+                                stage_tables_ldts=stage_tables_ldts,
+                                source_model=source_model) -}}
+
+{%- endmacro -%}

--- a/macros/tables/spark/eff_sat.sql
+++ b/macros/tables/spark/eff_sat.sql
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Business Thinking Ltd. 2019-2025
+ * This software includes code developed by the AutomateDV (f.k.a dbtvault) Team at Business Thinking Ltd. Trading as Datavault
+ */
+
+{%- macro spark__eff_sat(src_pk, src_dfk, src_sfk, src_extra_columns, src_start_date, src_end_date, src_eff, src_ldts, src_source, source_model) -%}
+
+{{- automate_dv.default__eff_sat(src_pk=src_pk, src_dfk=src_dfk, src_sfk=src_sfk,
+                                 src_extra_columns=src_extra_columns,
+                                 src_start_date=src_start_date, src_end_date=src_end_date,
+                                 src_eff=src_eff, src_ldts=src_ldts, src_source=src_source,
+                                 source_model=source_model) -}}
+
+{%- endmacro -%}

--- a/macros/tables/spark/hub.sql
+++ b/macros/tables/spark/hub.sql
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Business Thinking Ltd. 2019-2025
+ * This software includes code developed by the AutomateDV (f.k.a dbtvault) Team at Business Thinking Ltd. Trading as Datavault
+ */
+
+{%- macro spark__hub(src_pk, src_nk, src_extra_columns, src_ldts, src_source, source_model) -%}
+
+{%- set source_cols = automate_dv.expand_column_list(columns=[src_pk, src_nk, src_extra_columns, src_ldts, src_source]) -%}
+
+{%- if model.config.materialized == 'vault_insert_by_rank' %}
+    {%- set source_cols_with_rank = source_cols + [config.get('rank_column')] -%}
+{%- endif %}
+
+{{ 'WITH ' -}}
+
+{%- set stage_count = source_model | length -%}
+
+{%- set ns = namespace(last_cte= "") -%}
+
+{%- for src in source_model -%}
+
+{%- set source_number = loop.index | string -%}
+
+row_rank_{{ source_number }} AS (
+    WITH qualify_workaround AS (
+        {%- if model.config.materialized == 'vault_insert_by_rank' %}
+        SELECT {{ automate_dv.prefix(source_cols_with_rank, 'rr') }}
+        {%- else %}
+        SELECT {{ automate_dv.prefix(source_cols, 'rr') }}
+        {%- endif %}
+        , ROW_NUMBER() OVER(
+            PARTITION BY {{ automate_dv.prefix([src_pk], 'rr') }}
+            ORDER BY {{ automate_dv.prefix([src_ldts], 'rr') }}
+        ) AS row_number
+        FROM {{ ref(src) }} as rr
+    )
+    {%- if model.config.materialized == 'vault_insert_by_rank' %}
+    SELECT {{ automate_dv.prefix(source_cols_with_rank, 'rr') }}
+    {%- else %}
+    SELECT {{ automate_dv.prefix(source_cols, 'rr') }}
+    {%- endif %} FROM qualify_workaround as rr
+    WHERE {{ automate_dv.multikey(src_pk, prefix='rr', condition='IS NOT NULL') }}
+    AND rr.row_number = 1
+    {%- set ns.last_cte = "row_rank_{}".format(source_number) %}
+),{{ "\n" if not loop.last }}
+{% endfor -%}
+{% if stage_count > 1 %}
+stage_union AS (
+    {%- for src in source_model %}
+    SELECT * FROM row_rank_{{ loop.index | string }}
+    {%- if not loop.last %}
+    UNION ALL
+    {%- endif %}
+    {%- endfor %}
+    {%- set ns.last_cte = "stage_union" %}
+),
+{%- endif -%}
+
+{%- if model.config.materialized == 'vault_insert_by_period' %}
+stage_mat_filter AS (
+    SELECT *
+    FROM {{ ns.last_cte }}
+    WHERE __PERIOD_FILTER__
+    {%- set ns.last_cte = "stage_mat_filter" %}
+),
+{%- elif model.config.materialized == 'vault_insert_by_rank' %}
+stage_mat_filter AS (
+    SELECT *
+    FROM {{ ns.last_cte }}
+    WHERE __RANK_FILTER__
+    {%- set ns.last_cte = "stage_mat_filter" %}
+),
+{%- endif -%}
+
+{%- if stage_count > 1 %}
+
+row_rank_union AS (
+    SELECT ru.*
+    FROM {{ ns.last_cte }} AS ru
+    WHERE {{ automate_dv.multikey(src_pk, prefix='ru', condition='IS NOT NULL') }}
+    QUALIFY ROW_NUMBER() OVER(
+        PARTITION BY {{ automate_dv.prefix([src_pk], 'ru') }}
+        ORDER BY {{ automate_dv.prefix([src_ldts], 'ru') }}, {{ automate_dv.prefix([src_source], 'ru') }} ASC
+    ) = 1
+    {%- set ns.last_cte = "row_rank_union" %}
+),
+{% endif %}
+records_to_insert AS (
+    SELECT {{ automate_dv.prefix(source_cols, 'a', alias_target='target') }}
+    FROM {{ ns.last_cte }} AS a
+    {%- if automate_dv.is_any_incremental() %}
+    LEFT JOIN {{ this }} AS d
+    ON {{ automate_dv.multikey(src_pk, prefix=['a','d'], condition='=') }}
+    WHERE {{ automate_dv.multikey(src_pk, prefix='d', condition='IS NULL') }}
+    {%- endif %}
+)
+
+SELECT * FROM records_to_insert
+
+{%- endmacro -%}

--- a/macros/tables/spark/link.sql
+++ b/macros/tables/spark/link.sql
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Business Thinking Ltd. 2019-2025
+ * This software includes code developed by the AutomateDV (f.k.a dbtvault) Team at Business Thinking Ltd. Trading as Datavault
+ */
+
+{%- macro spark__link(src_pk, src_fk, src_extra_columns, src_ldts, src_source, source_model) -%}
+
+{%- set source_cols = automate_dv.expand_column_list(columns=[src_pk, src_fk, src_extra_columns, src_ldts, src_source]) -%}
+{%- set fk_cols = automate_dv.expand_column_list([src_fk]) -%}
+
+{%- if model.config.materialized == 'vault_insert_by_rank' %}
+    {%- set source_cols_with_rank = source_cols + [config.get('rank_column')] -%}
+{%- endif %}
+
+{{ 'WITH ' -}}
+
+{%- set stage_count = source_model | length -%}
+
+{%- set ns = namespace(last_cte= "") -%}
+
+{%- for src in source_model -%}
+
+{%- set source_number = loop.index | string -%}
+
+row_rank_{{ source_number }} AS (
+    WITH qualify_workaround AS (
+        {%- if model.config.materialized == 'vault_insert_by_rank' %}
+        SELECT {{ automate_dv.prefix(source_cols_with_rank, 'rr') }}
+        {%- else %}
+        SELECT {{ automate_dv.prefix(source_cols, 'rr') }}
+        {%- endif %}
+        , ROW_NUMBER() OVER(
+            PARTITION BY {{ automate_dv.prefix([src_pk], 'rr') }}
+            ORDER BY {{ automate_dv.prefix([src_ldts], 'rr') }}
+        ) AS row_number
+        FROM {{ ref(src) }} AS rr
+    )
+    {%- if model.config.materialized == 'vault_insert_by_rank' %}
+    SELECT {{ automate_dv.prefix(source_cols_with_rank, 'rr') }}
+    {%- else %}
+    SELECT {{ automate_dv.prefix(source_cols, 'rr') }}
+    {%- endif %}
+    FROM qualify_workaround AS rr
+    WHERE
+    {%- if stage_count == 1 %}
+    {{ automate_dv.multikey(src_pk, prefix='rr', condition='IS NOT NULL') }}
+    AND {{ automate_dv.multikey(fk_cols, prefix='rr', condition='IS NOT NULL') }}
+    AND
+    {%- endif %}
+    rr.row_number = 1
+    {%- set ns.last_cte = "row_rank_{}".format(source_number) %}
+),{{ "\n" if not loop.last }}
+{% endfor -%}
+
+{% if stage_count > 1 %}
+stage_union AS (
+    {%- for src in source_model %}
+    SELECT * FROM row_rank_{{ loop.index | string }}
+    {%- if not loop.last %}
+    UNION ALL
+    {%- endif %}
+    {%- endfor %}
+    {%- set ns.last_cte = "stage_union" %}
+),
+{%- endif -%}
+{%- if model.config.materialized == 'vault_insert_by_period' %}
+stage_mat_filter AS (
+    SELECT *
+    FROM {{ ns.last_cte }}
+    WHERE __PERIOD_FILTER__
+    {%- set ns.last_cte = "stage_mat_filter" %}
+),
+{%- elif model.config.materialized == 'vault_insert_by_rank' %}
+stage_mat_filter AS (
+    SELECT *
+    FROM {{ ns.last_cte }}
+    WHERE __RANK_FILTER__
+    {%- set ns.last_cte = "stage_mat_filter" %}
+),
+{% endif %}
+{%- if stage_count > 1 %}
+
+row_rank_union AS (
+    WITH qualify_workaround2 AS (
+        SELECT 
+            ru.*,
+            ROW_NUMBER() OVER(
+                PARTITION BY {{ automate_dv.prefix([src_pk], 'ru') }}
+                ORDER BY {{ automate_dv.prefix([src_ldts], 'ru') }}, {{ automate_dv.prefix([src_source], 'ru') }} ASC
+            ) AS row_number
+        FROM {{ ns.last_cte }} AS ru
+        WHERE {{ automate_dv.multikey(src_pk, prefix='ru', condition='IS NOT NULL') }}
+        AND {{ automate_dv.multikey(fk_cols, prefix='ru', condition='IS NOT NULL') }}
+    )
+    SELECT ru.*
+    FROM qualify_workaround2 AS ru
+    WHERE ru.row_number = 1
+    {%- set ns.last_cte = "row_rank_union" %}
+),
+{% endif %}
+records_to_insert AS (
+    SELECT {{ automate_dv.prefix(source_cols, 'a', alias_target='target') }}
+    FROM {{ ns.last_cte }} AS a
+    {%- if automate_dv.is_any_incremental() %}
+    LEFT JOIN {{ this }} AS d
+    ON {{ automate_dv.multikey(src_pk, prefix=['a','d'], condition='=') }}
+    WHERE {{ automate_dv.multikey(src_pk, prefix='d', condition='IS NULL') }}
+    {%- endif %}
+)
+
+SELECT * FROM records_to_insert
+
+{%- endmacro -%}

--- a/macros/tables/spark/ma_sat.sql
+++ b/macros/tables/spark/ma_sat.sql
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Business Thinking Ltd. 2019-2025
+ * This software includes code developed by the AutomateDV (f.k.a dbtvault) Team at Business Thinking Ltd. Trading as Datavault
+ */
+
+{%- macro spark__ma_sat(src_pk, src_cdk, src_hashdiff, src_payload, src_extra_columns, src_eff, src_ldts, src_source, source_model) -%}
+
+{{- automate_dv.default__ma_sat(src_pk=src_pk, src_cdk=src_cdk,
+                                  src_hashdiff=src_hashdiff, src_payload=src_payload,
+                                  src_extra_columns=src_extra_columns, src_eff=src_eff,
+                                  src_ldts=src_ldts, src_source=src_source,
+                                  source_model=source_model) -}}
+
+{%- endmacro -%}

--- a/macros/tables/spark/pit.sql
+++ b/macros/tables/spark/pit.sql
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Business Thinking Ltd. 2019-2025
+ * This software includes code developed by the AutomateDV (f.k.a dbtvault) Team at Business Thinking Ltd. Trading as Datavault
+ */
+
+{%- macro spark__pit(src_pk, src_extra_columns, as_of_dates_table, satellites, stage_tables_ldts, src_ldts, source_model) -%}
+
+{{- automate_dv.default__pit(src_pk=src_pk,
+                             src_extra_columns=src_extra_columns,
+                             as_of_dates_table=as_of_dates_table,
+                             satellites=satellites,
+                             stage_tables_ldts=stage_tables_ldts,
+                             src_ldts=src_ldts,
+                             source_model=source_model) -}}
+
+{%- endmacro -%}

--- a/macros/tables/spark/ref_table.sql
+++ b/macros/tables/spark/ref_table.sql
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Business Thinking Ltd. 2019-2025
+ * This software includes code developed by the AutomateDV (f.k.a dbtvault) Team at Business Thinking Ltd. Trading as Datavault
+ */
+
+{%- macro spark__ref_table(src_pk, src_extra_columns, src_ldts, src_source, source_model) -%}
+
+{{- automate_dv.default__ref_table(src_pk=src_pk,
+                                   src_extra_columns=src_extra_columns,
+                                   src_ldts=src_ldts,
+                                   src_source=src_source,
+                                   source_model=source_model) -}}
+
+{%- endmacro -%}

--- a/macros/tables/spark/sat.sql
+++ b/macros/tables/spark/sat.sql
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Business Thinking Ltd. 2019-2025
+ * This software includes code developed by the AutomateDV (f.k.a dbtvault) Team at Business Thinking Ltd. Trading as Datavault
+ */
+
+{%- macro spark__sat(src_pk, src_hashdiff, src_payload, src_extra_columns, src_eff, src_ldts, src_source, source_model) -%}
+
+{%- set apply_source_filter = config.get('apply_source_filter', false) -%}
+{%- set enable_ghost_record = var('enable_ghost_records', false) %}
+
+{%- set source_cols = automate_dv.expand_column_list(columns=[src_pk, src_hashdiff, src_payload, src_extra_columns, src_eff, src_ldts, src_source]) -%}
+{%- set window_cols = automate_dv.expand_column_list(columns=[src_pk, src_hashdiff, src_ldts]) -%}
+{%- set pk_cols = automate_dv.expand_column_list(columns=[src_pk]) -%}
+
+{%- if model.config.materialized == 'vault_insert_by_rank' %}
+    {%- set source_cols_with_rank = source_cols + [config.get('rank_column')] -%}
+{%- endif %}
+
+WITH source_data AS (
+    {%- if model.config.materialized == 'vault_insert_by_rank' %}
+    SELECT {{ automate_dv.prefix(source_cols_with_rank, 'a', alias_target='source') }}
+    {%- else %}
+    SELECT {{ automate_dv.prefix(source_cols, 'a', alias_target='source') }}
+    {%- endif %}
+    FROM {{ ref(source_model) }} AS a
+    WHERE {{ automate_dv.multikey(src_pk, prefix='a', condition='IS NOT NULL') }}
+    {%- if model.config.materialized == 'vault_insert_by_period' %}
+    AND __PERIOD_FILTER__
+    {% elif model.config.materialized == 'vault_insert_by_rank' %}
+    AND __RANK_FILTER__
+    {% endif %}
+),
+
+{%- if automate_dv.is_any_incremental() %}
+
+latest_records AS (
+    WITH qualify_workaround AS (
+        SELECT {{ automate_dv.prefix(window_cols, 'current_records', alias_target='target') }}
+        , ROW_NUMBER() OVER (
+        PARTITION BY {{ automate_dv.prefix([src_pk], 'current_records') }}
+        ORDER BY {{ automate_dv.prefix([src_ldts], 'current_records') }} DESC
+        ) AS row_number
+        FROM {{ this }}  AS current_records
+        JOIN (
+                SELECT DISTINCT {{ automate_dv.prefix([src_pk], 'source_data') }}
+                FROM source_data
+            ) AS source_records
+                ON {{ automate_dv.multikey(src_pk, prefix=['source_records','current_records'], condition='=') }}           
+    )
+    SELECT {{ automate_dv.prefix(window_cols, 'current_records', alias_target='target') }}
+    FROM qualify_workaround AS current_records
+    WHERE row_number = 1
+),
+
+{%- if apply_source_filter %}
+
+valid_stg AS (
+    SELECT {{ automate_dv.prefix(source_cols, 's', alias_target='source') }}
+    FROM source_data AS s
+    LEFT JOIN latest_records AS sat
+        ON {{ automate_dv.multikey(src_pk, prefix=['s', 'sat'], condition='=') }}
+        WHERE {{ automate_dv.multikey(src_pk, prefix='sat', condition='IS NULL') }}
+        OR {{ automate_dv.prefix([src_ldts], 's') }} > (
+            SELECT MAX({{ src_ldts }}) FROM latest_records AS sat
+            WHERE {{ automate_dv.multikey(src_pk, prefix=['sat','s'], condition='=') }}
+        )
+),
+{%- endif %}
+
+{%- endif %}
+
+{%- set is_incremental = automate_dv.is_any_incremental() -%}
+{%- set use_valid_stg = is_incremental and apply_source_filter -%}
+{%- set source_table = 'valid_stg AS sd' if use_valid_stg else 'source_data AS sd' -%}
+{%- set hashdiff_alias = automate_dv.prefix([src_hashdiff], 'sd', alias_target='source') -%}
+{%- set lag_default = automate_dv.cast_binary('FFFFFFFF', quote=true) -%}
+{%- set partition_by = automate_dv.prefix([src_pk], 'sd', alias_target='source') -%}
+{%- set is_bigquery = target.type == 'bigquery' -%}
+{%- set order_by = automate_dv.prefix([src_ldts], 'sd', alias_target='source') -%}
+
+{%- set use_eff = automate_dv.is_something(src_eff) -%}
+
+{%- if use_eff -%}
+    {%- set order_by_eff = automate_dv.prefix([src_eff], 'sd', alias_target='source') -%}
+{%- endif -%}
+
+{#- BigQuery does not support a 3-arg LAG() where the third arg is an expression, it must be a constant. Workaround below #}
+
+unique_source_records AS (
+    WITH qualify_workaround AS (
+        SELECT
+            {{ automate_dv.prefix(source_cols, 'sd', alias_target='source') }}
+            , {{ hashdiff_alias }}
+            , 
+            {%- if is_incremental and not is_bigquery %}
+                LAG({{ hashdiff_alias }}, 1,
+                    COALESCE(
+                        {{ automate_dv.prefix([src_hashdiff], 'lr', alias_target='target') }},
+                        {{ lag_default }}
+                    )
+                ) OVER (
+                    PARTITION BY {{ partition_by }}
+                    {%- if use_eff %}
+                    ORDER BY {{ order_by }} ASC,
+                            {{ order_by_eff }} ASC
+                    {%- else %}
+                    ORDER BY {{ order_by }} ASC
+                    {%- endif %}
+                )
+            {%- else %}
+                LAG({{ hashdiff_alias }}, 1, {{ lag_default }}) OVER (
+                    PARTITION BY {{ partition_by }}
+                    {%- if use_eff %}
+                    ORDER BY {{ order_by }} ASC,
+                            {{ order_by_eff }} ASC
+                    {%- else %}
+                    ORDER BY {{ order_by }} ASC
+                    {%- endif %}
+                )
+            {%- endif %} AS lag_column
+        FROM {{ source_table }} 
+        {%- if is_incremental %}
+        LEFT OUTER JOIN latest_records AS lr
+            ON {{ automate_dv.multikey(src_pk, prefix=['sd','lr'], condition='=') }}
+        {%- endif %}
+    )
+    SELECT
+        {{ automate_dv.prefix(source_cols, 'sd', alias_target='source') }}
+    FROM qualify_workaround AS sd
+    WHERE {{ hashdiff_alias }} != sd.lag_column
+),
+
+{%- if enable_ghost_record %}
+
+ghost AS (
+    {{ automate_dv.create_ghost_record(src_pk=src_pk, src_hashdiff=src_hashdiff,
+                                       src_payload=src_payload, src_extra_columns=src_extra_columns,
+                                       src_eff=src_eff, src_ldts=src_ldts,
+                                       src_source=src_source, source_model=source_model) }}
+),
+
+{%- endif %}
+
+records_to_insert AS (
+    {%- if enable_ghost_record %}
+    SELECT
+    {{ automate_dv.alias_all(source_cols, 'g') }}
+    FROM ghost AS g
+    {%- if automate_dv.is_any_incremental() %}
+    WHERE NOT EXISTS ( SELECT 1 FROM {{ this }} AS h WHERE {{ automate_dv.prefix([src_hashdiff], 'h', alias_target='target') }} = {{ automate_dv.prefix([src_hashdiff], 'g') }} )
+    {% else %}
+    WHERE NOT EXISTS ( SELECT 1 FROM source_data AS h WHERE {{ automate_dv.prefix([src_hashdiff], 'h', alias_target='source') }} = {{ automate_dv.prefix([src_hashdiff], 'g') }} )
+    {%- endif %}
+    UNION {%- if target.type == 'bigquery' %} DISTINCT {%- endif %}
+    {%- endif %}
+    SELECT {{ automate_dv.alias_all(source_cols, 'usr') }}
+    FROM unique_source_records AS usr
+)
+
+SELECT * FROM records_to_insert
+
+{%- endmacro -%}

--- a/macros/tables/spark/t_link.sql
+++ b/macros/tables/spark/t_link.sql
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Business Thinking Ltd. 2019-2025
+ * This software includes code developed by the AutomateDV (f.k.a dbtvault) Team at Business Thinking Ltd. Trading as Datavault
+ */
+
+{%- macro spark__t_link(src_pk, src_fk, src_payload, src_extra_columns, src_eff, src_ldts, src_source, source_model) -%}
+
+{{- automate_dv.default__t_link(src_pk=src_pk, src_fk=src_fk, src_payload=src_payload,
+                                src_extra_columns=src_extra_columns,
+                                src_eff=src_eff, src_ldts=src_ldts, src_source=src_source,
+                                source_model=source_model) -}}
+
+{%- endmacro -%}

--- a/macros/tables/spark/xts.sql
+++ b/macros/tables/spark/xts.sql
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Business Thinking Ltd. 2019-2025
+ * This software includes code developed by the AutomateDV (f.k.a dbtvault) Team at Business Thinking Ltd. Trading as Datavault
+ */
+
+{%- macro spark__xts(src_pk, src_satellite, src_extra_columns, src_ldts, src_source, source_model) -%}
+
+{{- automate_dv.default__xts(src_pk=src_pk,
+                             src_satellite=src_satellite,
+                             src_extra_columns=src_extra_columns,
+                             src_ldts=src_ldts,
+                             src_source=src_source,
+                             source_model=source_model) -}}
+
+{%- endmacro -%}


### PR DESCRIPTION
**Goal**: Add support for open-source Spark as a platform for on-premise spark clusters. 
**Changes**: Most macros works the same way as for the Databricks or Snowflake platform. Main change is for hub, satellite and link macros where QUALIFY keyword was being used in the default implementation, which is currently not supported by open-source Spark (see this Jira which is open since 2020 https://issues.apache.org/jira/browse/SPARK-31561 ). As a work-around, we define a CTE named qualify_workaround to perform the windowing functions first (ROW_NUMBER, LAG) and then perform the select.

**Testing**:
Has been tested for Spark 3.5.0.

**Next steps**:
Once `qualify` keyword is supported by open-source Spark (eg if Databricks contributes back to the open-source community), the macros can be simplified greatly by invoking default implementations.