### PR TITLE
Add src_eff, if provided, to ordering of latest sat records too

### DIFF
--- a/macros/tables/snowflake/sat.sql
+++ b/macros/tables/snowflake/sat.sql
@@ -29,7 +29,7 @@
 {%- set enable_ghost_record = var('enable_ghost_records', false) %}
 
 {%- set source_cols = automate_dv.expand_column_list(columns=[src_pk, src_hashdiff, src_payload, src_extra_columns, src_eff, src_ldts, src_source]) -%}
-{%- set window_cols = automate_dv.expand_column_list(columns=[src_pk, src_hashdiff, src_ldts]) -%}
+{%- set window_cols = automate_dv.expand_column_list(columns=[src_pk, src_hashdiff, src_ldts, src_eff]) -%}
 {%- set pk_cols = automate_dv.expand_column_list(columns=[src_pk]) -%}
 
 {%- if model.config.materialized == 'vault_insert_by_rank' %}
@@ -64,6 +64,9 @@ latest_records AS (
     QUALIFY ROW_NUMBER() OVER (
         PARTITION BY {{ automate_dv.prefix([src_pk], 'current_records') }}
         ORDER BY {{ automate_dv.prefix([src_ldts], 'current_records') }} DESC
+        {%- if automate_dv.is_something(src_eff) -%}
+        , {{ automate_dv.prefix([src_eff], 'current_records') }} DESC
+        {%- endif %}
     ) = 1
 ),
 


### PR DESCRIPTION
- -
Changes made to sat macro, in order to enable proper ordering during load of intra-day changes with same load_dt but different src_eff:
- added optional src_eff parameter to window_cols list, used in latest_records CTE 
- if src_eff is provided, it is added to order by clause together with load_dt in latest records CTE (to locate latest latest record from existing target)