### PR TITLE
Fix dbt meta config warnings using config.meta_get

### DIFF
--- a/macros/supporting/fusion_compat.sql
+++ b/macros/supporting/fusion_compat.sql
@@ -1,23 +1,35 @@
 {% macro config_meta_get(key, default=none) %}
-    {%- if config.get(key) != none -%}
-        {{ return(config.get(key)) }}
-    {%- elif config.get("meta") != none and (key in config.get("meta", {}).keys()) -%}
-        {{ return(config.get("meta").get(key)) }}
-    {%- else -%}
-        {{ return(default) }}
+    {# 1. Try to get from meta #}
+    {%- set meta_val = config.meta_get(key) -%}
+    {%- if meta_val != none -%}
+        {{ return(meta_val) }}
     {%- endif -%}
+
+    {# 2. If not found in meta, try the standard config #}
+    {# This line is now safe because we know the key is NOT in meta #}
+    {%- set config_val = config.get(key) -%}
+    {%- if config_val != none -%}
+        {{ return(config_val) }}
+    {%- endif -%}
+
+    {# 3. Return default if found in neither #}
+    {{ return(default) }}
 {% endmacro %}
 
 
 {% macro config_meta_require(key) %}
-    {# the first case is required to avoid errors #}
-    {%- if config == {} -%}
-        {{ return(none) }}
-    {%- elif config.get(key) != none -%}
-        {{ return(config.get(key)) }}
-    {%- elif config.get("meta") != none and (key in config.get("meta", {}).keys()) -%}
-        {{ return(config.get("meta").get(key)) }}
-    {%- else -%}
-        {% do exceptions.raise_compiler_error("Configuration '" ~ key ~ "' is required but was not found under config or meta (Fusion requires custom configuration under meta)") %}
+    {# 1. Try to get from meta #}
+    {%- set meta_val = config.meta_require(key) -%}
+    {%- if meta_val != none -%}
+        {{ return(meta_val) }}
     {%- endif -%}
+
+    {# 2. If not found in meta, try the standard config #}
+    {%- set config_val = config.require(key) -%}
+    {%- if config_val != none -%}
+        {{ return(config_val) }}
+    {%- endif -%}
+
+    {# 3. Raise error if found in neither #}
+    {% do exceptions.raise_compiler_error("Configuration '" ~ key ~ "' is required but was not found under config or meta (Fusion requires custom configuration under meta)") %}
 {% endmacro %}

--- a/macros/supporting/fusion_compat.sql
+++ b/macros/supporting/fusion_compat.sql
@@ -1,14 +1,16 @@
 {% macro config_meta_get(key, default=none) %}
-    {# 1. Try to get from meta #}
-    {%- set meta_val = config.meta_get(key) -%}
-    {%- if meta_val != none -%}
-        {{ return(meta_val) }}
+    {# 1. Try to get from meta dictionary directly #}
+    {%- set meta = config.get('meta') or {} -%}
+    
+    {# We check if the key exists inside the meta dictionary #}
+    {%- if key in meta -%}
+        {{ return(meta[key]) }}
     {%- endif -%}
 
     {# 2. If not found in meta, try the standard config #}
-    {# This line is now safe because we know the key is NOT in meta #}
     {%- set config_val = config.get(key) -%}
-    {%- if config_val != none -%}
+    
+    {%- if config_val is not none -%}
         {{ return(config_val) }}
     {%- endif -%}
 
@@ -18,18 +20,21 @@
 
 
 {% macro config_meta_require(key) %}
-    {# 1. Try to get from meta #}
-    {%- set meta_val = config.meta_require(key) -%}
-    {%- if meta_val != none -%}
-        {{ return(meta_val) }}
+    {# 1. Try to get from meta dictionary directly #}
+    {%- set meta = config.get('meta') or {} -%}
+    
+    {# We check if the key exists inside the meta dictionary #}
+    {%- if key in meta -%}
+        {{ return(meta[key]) }}
     {%- endif -%}
 
     {# 2. If not found in meta, try the standard config #}
-    {%- set config_val = config.require(key) -%}
-    {%- if config_val != none -%}
+    {%- set config_val = config.get(key) -%}
+    
+    {%- if config_val is not none -%}
         {{ return(config_val) }}
     {%- endif -%}
 
     {# 3. Raise error if found in neither #}
-    {% do exceptions.raise_compiler_error("Configuration '" ~ key ~ "' is required but was not found under config or meta (Fusion requires custom configuration under meta)") %}
+    {% do exceptions.raise_compiler_error("Configuration '" ~ key ~ "' is required but was not found under config or meta") %}
 {% endmacro %}


### PR DESCRIPTION
This PR updates the config_meta_get and config_meta_require macros to prioritize checking the meta dictionary before falling back to standard configuration lookups.

The Issue:



Ambiguity Warning: Accessing a key that exists in meta via config.get(key) triggers a dbt warning: 
```
[WARNING]: The key 'apply_source_filter' was not found using config.get('apply_source_filter'), but was detected as a custom config under 'meta'. Please use config.meta_get('apply_source_filter') or config.meta_require('apply_source_filter') instead of config.get('apply_source_filter') to access the custom config value if intended.
```

The Solution: To resolve the issue, the macros now manually inspect the dictionary:

Retrieve the full meta dictionary using config.get('meta', {}).

Check if the requested key exists directly in that dictionary.

If found, return it immediately (bypassing the root lookup that triggers the warning).

If not found, safely fall back to config.get(key) for root-level configurations.

This approach successfully silences the warnings while preventing the AttributeError crashes associated with the missing meta_get method.

We are having this deprecation warning in `dbt-core` 1.10.10 and in `dbt-cloud` in the latest version 